### PR TITLE
Create client module to avoid circular import

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 ## Available Modules
 
+### `client`
+
+Facilitate interactions with low-level service clients.
+
 ### `secrets`
 
 Facilitate interactions with Secrets Manager.

--- a/topshelfsoftware_aws_util/__init__.py
+++ b/topshelfsoftware_aws_util/__init__.py
@@ -1,46 +1,12 @@
 import logging
 from typing import List, Union
 
-from boto3.session import Session as Boto3Session
-from botocore.client import BaseClient
-from botocore.exceptions import ClientError as BotoClientError
-
+from topshelfsoftware_aws_util.client import logger as client_logger
 from topshelfsoftware_aws_util.secrets import logger as secrets_logger
 from topshelfsoftware_aws_util.sfn import logger as sfn_logger
 from topshelfsoftware_aws_util.ssm import logger as ssm_logger
-from topshelfsoftware_util.log import get_logger
 
 PACKAGE_NAME = "topshelfsoftware-aws-util"
-
-logger = get_logger(PACKAGE_NAME, stream=None)
-
-
-def create_boto3_client(service_name: str, region: str = None) -> BaseClient:
-    """Create a low-level service client by name.
-
-    Parameters
-    ----------
-    service_name: str
-        Name of the AWS service.
-    
-    region: str, optional
-        Region where service abides.
-        Default is `None`.
-    
-    Returns
-    -------
-    botocore.client.BaseClient
-        AWS low-level service client.
-    """
-    logger.debug(f"creating boto3 client: {service_name}")
-    try:
-        session = Boto3Session(region_name=region)
-        client = session.client(service_name=service_name)
-    except BotoClientError as e:
-        logger.error(f"failed to create client: {service_name}. Reason: {e}")
-        raise e
-    logger.debug("boto3 client successfully created")
-    return client
 
 
 def debug():
@@ -52,7 +18,7 @@ def debug():
 def get_package_loggers() -> List[logging.Logger]:
     """Retrieve a list of the Loggers used in the package."""
     loggers = [
-        logger, secrets_logger, sfn_logger, ssm_logger
+        client_logger, secrets_logger, sfn_logger, ssm_logger
     ]
     return loggers
 

--- a/topshelfsoftware_aws_util/client.py
+++ b/topshelfsoftware_aws_util/client.py
@@ -1,0 +1,37 @@
+"""Facilitate interactions with low-level service clients."""
+
+from boto3.session import Session as Boto3Session
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError as BotoClientError
+
+from topshelfsoftware_util.log import get_logger
+
+logger = get_logger(__name__, stream=None)
+
+
+def create_boto3_client(service_name: str, region: str = None) -> BaseClient:
+    """Create a low-level service client by name.
+
+    Parameters
+    ----------
+    service_name: str
+        Name of the AWS service.
+    
+    region: str, optional
+        Region where service abides.
+        Default is `None`.
+    
+    Returns
+    -------
+    botocore.client.BaseClient
+        AWS low-level service client.
+    """
+    logger.debug(f"creating boto3 client: {service_name}")
+    try:
+        session = Boto3Session(region_name=region)
+        client = session.client(service_name=service_name)
+    except BotoClientError as e:
+        logger.error(f"failed to create client: {service_name}. Reason: {e}")
+        raise e
+    logger.debug("boto3 client successfully created")
+    return client

--- a/topshelfsoftware_aws_util/secrets.py
+++ b/topshelfsoftware_aws_util/secrets.py
@@ -2,7 +2,7 @@
 
 from botocore.exceptions import ClientError as BotoClientError
 
-from topshelfsoftware_aws_util import create_boto3_client
+from topshelfsoftware_aws_util.client import create_boto3_client
 from topshelfsoftware_util.json import fmt_json
 from topshelfsoftware_util.log import get_logger
 

--- a/topshelfsoftware_aws_util/sfn.py
+++ b/topshelfsoftware_aws_util/sfn.py
@@ -5,7 +5,7 @@ import json
 import time
 import uuid
 
-from topshelfsoftware_aws_util import create_boto3_client
+from topshelfsoftware_aws_util.client import create_boto3_client
 from topshelfsoftware_util.json import fmt_json
 from topshelfsoftware_util.log import get_logger
 

--- a/topshelfsoftware_aws_util/ssm.py
+++ b/topshelfsoftware_aws_util/ssm.py
@@ -2,7 +2,7 @@
 
 from botocore.exceptions import ClientError as BotoClientError
 
-from topshelfsoftware_aws_util import create_boto3_client
+from topshelfsoftware_aws_util.client import create_boto3_client
 from topshelfsoftware_util.json import fmt_json
 from topshelfsoftware_util.log import get_logger
 


### PR DESCRIPTION
This change has been verified to fix the circular ImportErrors seen when using `pytest` unit tests