### PR TITLE
Add Unit Tests with CI/CD

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Package Build
 on:
   push:
     branches:
-      - testing/add-tests
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: Package Build
+
+on:
+  push:
+    branches:
+      - testing/add-tests
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-package-python3:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        python-ver: ['3.12', '3.11', '3.10', '3.9']
+    
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      # Setup Python (faster than using Python container)
+      - name: Install Python ${{ matrix.python-ver }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-ver }}
+
+      - name: Setup dev environment
+        run: make setup
+
+      - name: Build package with poetry
+        run: make package

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Code Coverage
 on:
   push:
     branches:
-      - testing/add-tests
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,43 @@
+name: Code Coverage
+
+on:
+  push:
+    branches:
+      - testing/add-tests
+  pull_request:
+    branches:
+      - main
+
+env:
+  # boto3 needs this env var if region is not
+  # specified when creating clients
+  AWS_DEFAULT_REGION: us-east-1
+
+jobs:
+  upload-code-cov:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        python-ver: ['3.12']
+    
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      # Setup Python (faster than using Python container)
+      - name: Install Python ${{ matrix.python-ver }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-ver }}
+
+      - name: Setup dev environment
+        run: make setup
+
+      - name: Run unit tests with pytest
+        run: make test
+      
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.2.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,38 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - testing/add-tests
+  pull_request:
+    branches:
+      - main
+
+env:
+  # boto3 needs this env var if region is not
+  # specified when creating clients
+  AWS_DEFAULT_REGION: us-east-1
+
+jobs:
+  unit-test-python3:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        python-ver: ['3.12', '3.11', '3.10', '3.9']
+    
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      # Setup Python (faster than using Python container)
+      - name: Install Python ${{ matrix.python-ver }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-ver }}
+
+      - name: Setup dev environment
+        run: make setup
+
+      - name: Run unit tests with pytest
+        run: make test

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,7 +3,7 @@ name: Unit Tests
 on:
   push:
     branches:
-      - testing/add-tests
+      - main
   pull_request:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -170,4 +170,5 @@ cython_debug/
 
 # project files
 local_pypi_dir.txt
+config.ini
 *artifacts/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: local
+  hooks:
+  - id: make-lint
+    name: Lint Code
+    entry: make lint
+    language: system
+    fail_fast: true
+- repo: local
+  hooks:
+  - id: make-test
+    name: Run Unit Tests
+    entry: make test-no-cov
+    language: system
+    fail_fast: true
+    stages: [push]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Top Shelf Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
     LOCAL_PYPI_DIR := $(shell cat ${LOCAL_PYPI_FP})
 endif
 PKG_NAME := topshelfsoftware_aws_util
-PKG_VER := 0.1.2
+PKG_VER := 0.2.0
 
 ####### BUILD TARGETS #######
 

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,105 @@
-SHELL := /bin/bash
-MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-MAKEFILE_DIR := $(realpath $(dir $(MAKEFILE_PATH)))
-CWD := $(notdir $(patsubst %/,%,$(dir $(MAKEFILE_PATH))))
-VENV_DIR := $(MAKEFILE_DIR)/.venv
-REQ_FP := $(MAKEFILE_DIR)/requirements.txt
+.PHONY: setup update clean \
+		format lint test package \
+		deploy-layer
 
-LOCAL_PYPI_FP := $(MAKEFILE_DIR)/local_pypi_dir.txt
-LOCAL_PYPI_DIR := $(shell cat ${LOCAL_PYPI_FP})
+####### USER INPUTS #######
+AWS_PROFILE :=				# required, no default value
+AWS_REGION ?= us-east-1
+S3_BUCKET :=				# required, no default value
+TAGS := 					# required, no default value
+
+####### CONSTANTS #######
+PROJ_ROOT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+VENV_DIR := $(PROJ_ROOT_DIR)/.venv
+PKG_DIR := $(PROJ_ROOT_DIR)/package
+PYTHON3 := python3
+LOCAL_PYPI_FP := $(PROJ_ROOT_DIR)/local_pypi_dir.txt
+ifeq ($(wildcard $(LOCAL_PYPI_FP)),)
+# file does not exist
+	LOCAL_PYPI_DIR :=
+else
+# file exists
+    LOCAL_PYPI_DIR := $(shell cat ${LOCAL_PYPI_FP})
+endif
 PKG_NAME := topshelfsoftware_aws_util
 PKG_VER := 0.1.1
 
-# function to activate the python virtual env
-activate = . $(VENV_DIR)/bin/activate && $1
+####### BUILD TARGETS #######
 
-.PHONY: build copy install
+# The setup target creates a virtual env and installs packages as well as pre-commit hooks.
+# It depends on the presence of two scripts: $(VENV_DIR)/bin/activate and $(VENV_DIR)/bin/pre-commit.
+# If a script doesn't exist, it will trigger the targets below to create the
+# virtual env, install packages, and/or install pre-commit hooks.
+setup: $(VENV_DIR)/bin/activate $(VENV_DIR)/bin/pre-commit
 
-all: build copy
+update: setup pip-install pre-commit-install
 
-build:
-	$(call activate,poetry build --format wheel)
+$(VENV_DIR)/bin/activate:
+	@$(MAKE) clean
+	@echo "Setting up development environment using $(PYTHON3)..."
+	$(PYTHON3) -m venv $(VENV_DIR)
+	@$(MAKE) pip-install
+	@$(MAKE) pre-commit-install
+	@echo "Development environment setup complete."
 
-copy:
-	cp $(MAKEFILE_DIR)/dist/$(PKG_NAME)-$(PKG_VER)*.whl $(LOCAL_PYPI_DIR)
+$(VENV_DIR)/bin/pre-commit:
+	@$(MAKE) pip-install
+	@$(MAKE) pre-commit-install
 
-install:
-	@echo "Setting up Python virtual env"
-	python3.9 -m venv $(VENV_DIR)
-	
-	@echo "Upgrading pip"
-	$(call activate,python -m pip install --upgrade pip)
+pip-install:
+	@echo "Upgrading pip..."
+	$(VENV_DIR)/bin/pip install --upgrade pip
+	@echo "Installing required Python packages..."
+	@find $(PROJ_ROOT_DIR) \
+		-path '*/.aws-sam' -prune -o \
+		-path '*/lambda_layer/no_deps' -prune -o \
+		-name 'requirements.txt' -print0 | \
+		xargs -0 -I {} sh -c '$(VENV_DIR)/bin/pip install -r "$$1"' _ {}
 
-	@echo "Installing project dependencies"
-	$(call activate,python -m pip install -r $(REQ_FP))
+pre-commit-install:
+	@echo "Installing pre-commit hooks..."
+	$(VENV_DIR)/bin/pre-commit install
+	$(VENV_DIR)/bin/pre-commit install --hook-type pre-push
+
+# Clean target to remove the virtual environment
+clean:
+	@echo "Removing virtual environment..."
+	rm -rf $(VENV_DIR)
+	@echo "Clean complete."
+
+# Format code using black, then lint using ruff
+format:
+	$(VENV_DIR)/bin/black $(PROJ_ROOT_DIR) && \
+		$(VENV_DIR)/bin/ruff check $(PROJ_ROOT_DIR) --fix
+
+lint:
+	$(VENV_DIR)/bin/ruff check $(PROJ_ROOT_DIR)
+
+# Run all tests
+test:
+	$(VENV_DIR)/bin/pytest -s -v -c $(PROJ_ROOT_DIR)/tests/pytest.ini \
+		--cov --cov-report term --cov-report html --cov-report xml --cov-config $(PROJ_ROOT_DIR)/tests/.coveragerc
+
+test-no-cov:
+	$(VENV_DIR)/bin/pytest -s -v -c $(PROJ_ROOT_DIR)/tests/pytest.ini
+
+# Python package
+package:
+	$(VENV_DIR)/bin/poetry build --format wheel && \
+	if [ -d "$(LOCAL_PYPI_DIR)" ]; then \
+		cp $(PROJ_ROOT_DIR)/dist/$(PKG_NAME)-$(PKG_VER)*.whl $(LOCAL_PYPI_DIR) && \
+		echo "Copied wheel to $(LOCAL_PYPI_DIR)"; \
+	fi
+
+# Lambda layer deployment
+deploy-layer: check-user-inp
+	export AWS_PROFILE=$(AWS_PROFILE) && \
+		sam build --config-file $(PROJ_ROOT_DIR)/samconfig.toml && \
+		sam deploy --config-file $(PROJ_ROOT_DIR)/samconfig.toml --config-env default --region $(AWS_REGION) --s3-bucket $(S3_BUCKET) --tags $(TAGS)
+
+# ensure the required variables are defined by the user
+check-user-inp:
+	$(if $(AWS_PROFILE),,$(error AWS_PROFILE is undefined. Usage: make deploy-layer AWS_PROFILE=<aws-profile> S3_BUCKET=<s3-bucket> TAGS="CustomerId={cid} ProjectId={pid}" [AWS_REGION=us-east-1]))
+	$(if $(AWS_REGION),,$(error AWS_REGION is undefined. Usage: make deploy-layer AWS_PROFILE=<aws-profile> S3_BUCKET=<s3-bucket> TAGS="CustomerId={cid} ProjectId={pid}" [AWS_REGION=us-east-1]))
+	$(if $(S3_BUCKET),,$(error S3_BUCKET is undefined. Usage: make deploy-layer AWS_PROFILE=<aws-profile> S3_BUCKET=<s3-bucket> TAGS="CustomerId={cid} ProjectId={pid}" [AWS_REGION=us-east-1]))
+	$(if $(TAGS),,$(error TAGS is undefined. Usage: make deploy-layer AWS_PROFILE=<aws-profile> S3_BUCKET=<s3-bucket> TAGS="CustomerId={cid} ProjectId={pid}" [AWS_REGION=us-east-1]))

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
     LOCAL_PYPI_DIR := $(shell cat ${LOCAL_PYPI_FP})
 endif
 PKG_NAME := topshelfsoftware_aws_util
-PKG_VER := 0.1.1
+PKG_VER := 0.1.2
 
 ####### BUILD TARGETS #######
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Utility functions for interacting with AWS.
 | | |
 | --- | --- |
 | Testing | [![CI - Test](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/unit-tests.yaml) [![codecov](https://codecov.io/gh/topshelfsoftware/python-aws-utility/graph/badge.svg?token=SK77CYUOBP)](https://codecov.io/gh/topshelfsoftware/python-aws-utility) |
-| Package | [![Build Status](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml/badge.svg)](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml) ![Package Version](https://img.shields.io/badge/latest-v0.1.2-blue) ![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12-blue?logo=python&logoColor=yellow) |
+| Package | [![Build Status](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml/badge.svg)](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml) ![Package Version](https://img.shields.io/badge/latest-v0.2.0-blue) ![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12-blue?logo=python&logoColor=yellow) |
 | Meta | [![License](https://img.shields.io/github/license/topshelfsoftware/python-aws-utility)](https://github.com/topshelfsoftware/python-aws-utility/blob/main/LICENSE) |
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -2,32 +2,74 @@
 
 Utility functions for interacting with AWS.
 
-## Makefile
+| | |
+| --- | --- |
+| Testing | [![CI - Test](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/unit-tests.yaml) [![codecov](https://codecov.io/gh/topshelfsoftware/python-aws-utility/graph/badge.svg?token=SK77CYUOBP)](https://codecov.io/gh/topshelfsoftware/python-aws-utility) |
+| Package | [![Build Status](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml/badge.svg)](https://github.com/topshelfsoftware/python-aws-utility/actions/workflows/build.yaml) ![Package Version](https://img.shields.io/badge/latest-v0.1.2-blue) ![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12-blue?logo=python&logoColor=yellow) |
+| Meta | [![License](https://img.shields.io/github/license/topshelfsoftware/python-aws-utility)](https://github.com/topshelfsoftware/python-aws-utility/blob/main/LICENSE) |
 
-A `Makefile` is provided to standardize building and publishing the Python package. Satisfy the following prerequisites to be successful:
+## Getting Started
 
-- Install Python 3.9 and add to PATH (executable name assumed to be `python3.9`)
-- Create a file named `local_pypi_dir.txt` in the project root directory (same folder as this `README`)
-  - Contents of file are a single line defining the path to a local directory to be used as a local PyPI repository
+### Prerequisites
 
-### Project Dependencies
+1. Python 3.9 | 3.10 | 3.11 | 3.12 installed on system
+2. `aws-sam-cli` with "sam" on system path
+3. Optionally, create a file named `local_pypi_dir.txt` in the project root directory (same folder as this `README`)
+    - Contents of file are a single line defining the path to a local directory to be used as a local PyPI repository.
 
-Install project dependencies by running the following command one time
+### Set Up Environment
 
-```bash
-# install project deps such as poetry
-make install
-```
-
-### Build Instructions
-
-Simply navigate to the same folder as this `README`, and run the following command to build and publish the utility package to a local PyPI repo.
+To create the dev environment, navigate to the project root directory and run the following
 
 ```bash
-make
+make setup [PYTHON3=python3]
 ```
 
-This command activates the virtual environment with `poetry`, builds the package as a wheel and copies it to the local PyPI repository.
+>NOTE: This command creates a virtual environment to `./.venv` and downloads all the
+packages required to debug/test the source code as well as other developer tools. Specify
+a minor version of Python 3 using the `PYTHON3=python3.<minor>` arg.
+
+If the dev environment has already been setup, then the dependencies can be updated with
+
+```bash
+make update [PYTHON3=python3]
+```
+
+### Unit Tests
+
+Unit tests are located in the `./tests` directory and are written using `pytest`.
+To run all unit tests, execute the following command from the project root directory
+
+```bash
+make test
+```
+
+### Formatting and Linting
+
+To ensure consistent style and catch potential errors, this repo formats Python code using `black` and
+lints Python code using `ruff`. To format and then lint, run
+
+```bash
+make format
+```
+
+## Deployment
+
+>NOTE: AWS deployment targets also require user be authenticated with relevant AWS account
+
+### Package and Lambda Layer
+
+Build the `topshelfsoftware-aws-util` Python package as a wheel and copy it to the local PyPI repository
+
+```bash
+make package
+```
+
+Further, deploy the package as a Lambda layer with
+
+```bash
+make deploy-layer AWS_PROFILE=<aws-profile> S3_BUCKET=<s3-bucket> TAGS="CustomerId={cid} ProjectId={pid}" [AWS_REGION=us-east-1]
+```
 
 ## Versioning
 
@@ -36,24 +78,11 @@ This package uses Semantic Versioning 2.0.0 to describe MAJOR.MINOR.PATCH releas
 IMPORTANT❗
 Search the project for the existing package version and update in the following places prior to building the package and deploying the lambda layer:
 
+- shields.io badge in this `README`
 - `PKG_VER` variable in the project `Makefile`
 - `version` in the poetry `pyproject.toml`
-- `PackageVersion` parameter in the `template.yaml`
+- `PackageVersion` parameter in the `samconfig.toml`
 - `topshelfsoftware-aws-util` package in the `lambda_layer/no_deps/requirements.txt`
-
-## Tagging
-
-After incrementing the package version (and merging PR), create an associated tag of the repository. Perform the following from the command line:
-
-```bash
-git tag -a <version> <commit_hash>
-```
-
-`<version>` will take the form vX.Y.Z where X.Y.Z represents MAJOR.MINOR.PATCH in semantic versioning. Then push the tag to the remote server using:
-
-```bash
-git push origin <version>
-```
 
 ## Available Modules
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 1%
+
+comment:
+  layout: "header, diff, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: false
+  hide_project_coverage: false

--- a/lambda_layer/deps/requirements.txt
+++ b/lambda_layer/deps/requirements.txt
@@ -1,1 +1,1 @@
-topshelfsoftware-util @ git+https://github.com/topshelfsoftware/python-utility.git@v1.0.0
+topshelfsoftware-util @ git+https://github.com/topshelfsoftware/python-utility.git@v1.1.0

--- a/lambda_layer/no_deps/requirements.txt
+++ b/lambda_layer/no_deps/requirements.txt
@@ -1,1 +1,1 @@
-topshelfsoftware-aws-util @ git+https://github.com/topshelfsoftware/python-aws-utility.git@v0.1.1
+topshelfsoftware-aws-util @ git+https://github.com/topshelfsoftware/python-aws-utility.git@v0.1.2

--- a/lambda_layer/no_deps/requirements.txt
+++ b/lambda_layer/no_deps/requirements.txt
@@ -1,1 +1,1 @@
-topshelfsoftware-aws-util @ git+https://github.com/topshelfsoftware/python-aws-utility.git@v0.1.2
+topshelfsoftware-aws-util @ git+https://github.com/topshelfsoftware/python-aws-utility.git@v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "topshelfsoftware_aws_util"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utility functions for interacting with AWS."
 license="MIT"
 authors = [
@@ -14,9 +14,9 @@ readme = "./docs/README.md"
 repository = "https://github.com/topshelfsoftware/python-aws-utility"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 boto3 = "^1.26"
-topshelfsoftware_util = { git = "https://github.com/topshelfsoftware/python-utility.git", tag = "v1.0.0" }
+topshelfsoftware_util = { git = "https://github.com/topshelfsoftware/python-utility.git", tag = "v1.1.0" }
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "topshelfsoftware_aws_util"
-version = "0.1.2"
+version = "0.2.0"
 description = "Utility functions for interacting with AWS."
 license="MIT"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core>=0.1.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "topshelfsoftware_aws_util"
 version = "0.1.1"
@@ -14,6 +18,13 @@ python = "^3.7"
 boto3 = "^1.26"
 topshelfsoftware_util = { git = "https://github.com/topshelfsoftware/python-utility.git", tag = "v1.0.0" }
 
-[build-system]
-requires = ["poetry-core>=0.1.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.black]
+line-length = 79
+
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
+ignore = []
+extend-select = ["C901", "E501"]
+mccabe.max-complexity = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-poetry>=1
+--trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org 
+# package deps
 boto3>=1.26
-topshelfsoftware-util @ git+https://github.com/topshelfsoftware/python-utility.git@v1.0.0
+
+# dev tools
+poetry~=1.8
+pre-commit~=3.7
+black>=24.4
+ruff>=0.5

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -17,7 +17,7 @@ tags = [
     "CustomerId=00000"
 ]
 parameter_overrides = [
-    "PackageVersion=v0.1.1"
+    "PackageVersion=v0.1.2"
 ]
 
 [prod.deploy.parameters]
@@ -30,5 +30,5 @@ tags = [
     "CustomerId=00000"
 ]
 parameter_overrides = [
-    "PackageVersion=v0.1.1"
+    "PackageVersion=v0.1.2"
 ]

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -16,5 +16,5 @@ tags = [
     "CustomerId=00000"
 ]
 parameter_overrides = [
-    "PackageVersion=v0.1.2"
+    "PackageVersion=v0.2.0"
 ]

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,27 +1,13 @@
 # Usage (specify env):
 #   sam deploy \
-#       --config-env [devl|prod] \
+#       --region [us-west-2] \
 #       --s3-bucket [bucket_name] \
 #       --tags CustomerId={customer_id} ProjectId={project_id}
 
 version=0.1
 [default]
 [default.deploy.parameters]
-[devl.deploy.parameters]
-region = "us-west-2"
-s3_prefix = "topshelfsoftware-aws-util-layer"
-stack_name = "topshelfsoftware-aws-util-layer"
-confirm_changeset = false
-capabilities = "CAPABILITY_IAM"
-tags = [
-    "CustomerId=00000"
-]
-parameter_overrides = [
-    "PackageVersion=v0.1.2"
-]
-
-[prod.deploy.parameters]
-region = "us-west-2"
+region = "us-east-1"
 s3_prefix = "topshelfsoftware-aws-util-layer"
 stack_name = "topshelfsoftware-aws-util-layer"
 confirm_changeset = true

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion : '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: AWS Python utility lambda layer
+Description: Python AWS utility lambda layer
 
 # Versioning: X.Y.Z
 # - X: breaking changes
@@ -30,6 +30,7 @@ Resources:
         - python3.9
         - python3.10
         - python3.11
+        - python3.12
       LicenseInfo: MIT
       RetentionPolicy: Retain
   

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = 
+    topshelfsoftware_aws_util
+
+[report]
+omit =
+    tests/*

--- a/tests/__setup__.py
+++ b/tests/__setup__.py
@@ -1,0 +1,24 @@
+import configparser
+import os
+import sys
+
+# add service and lambdas dir to system path, otherwise cannot import modules
+PROJ_ROOT_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), os.pardir
+)
+PACKAGE_PATH = os.path.join(PROJ_ROOT_PATH, "topshelfsoftware_aws_util")
+sys.path.append(PROJ_ROOT_PATH)
+sys.path.append(PACKAGE_PATH)
+
+# test file paths
+TESTS_PATH = os.path.join(PROJ_ROOT_PATH, "tests")
+TEST_EVENTS_PATH = os.path.join(TESTS_PATH, "events")
+
+# parse config.ini file if it exists to support aws-cli authentication
+CONFIG_INI_PATH = os.path.join(TESTS_PATH, "config.ini")
+if os.path.isfile(CONFIG_INI_PATH):
+    config = configparser.RawConfigParser()
+    config.read(CONFIG_INI_PATH)
+    config_dict = dict(config.items("main"))
+    for k, v in config_dict.items():
+        os.environ[k.upper()] = v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+import glob
+import json
+import os
+import sys
+from typing import Generator
+
+import pytest
+import yaml
+
+import __setup__  # noqa: F401 - need __setup__ for sys path imports to work
+from topshelfsoftware_util.log import get_logger
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+FILE_DELIMITER = "-"
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger("conftest", stream=sys.stdout)
+
+
+# ----------------------------------------------------------------------------#
+#                                 --- MAIN ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.fixture
+def get_event_as_dict(
+    event_dir: str, event_file: str
+) -> Generator[dict, None, None]:
+    """Read a JSON-formatted file into a Python dictionary."""
+    event_fp = os.path.join(event_dir, event_file)
+    event = convert_json_to_dict(event_fp)
+    yield event
+
+
+@pytest.fixture
+def get_event_as_str(
+    event_dir: str, event_file: str
+) -> Generator[str, None, None]:
+    """Read a JSON-formatted file into a Python string."""
+    event_fp = os.path.join(event_dir, event_file)
+    logger.info(f"reading JSON file {event_file} into string")
+    with open(event_fp, "r") as fp:
+        event = fp.read()
+    yield event
+
+
+def get_json_files(dirname: str, matching: list[str] = None) -> list[str]:
+    """Obtain all json files or a subset of the json files
+    matching the provided string."""
+    all_event_files = [
+        os.path.basename(x)
+        for x in sorted(glob.glob(os.path.join(dirname, "*.json")))
+    ]
+    subset = []
+    for file_name in all_event_files:
+        file_no_ext, _ = os.path.splitext(file_name)
+        file_kw = file_no_ext.split(FILE_DELIMITER)
+        if matching is None or set(matching).issubset(set(file_kw)):
+            subset.append(file_name)
+    return subset
+
+
+def convert_json_to_dict(json_fp: str) -> dict:
+    """Read a JSON-formatted file into a Python dictionary."""
+    logger.info(f"reading JSON file {json_fp} into dict")
+    with open(json_fp, "r") as fp:
+        json_dict = json.load(fp)
+    return json_dict
+
+
+def convert_yaml_to_dict(yaml_fp: str) -> dict:
+    """Read a YAML-formatted file into a Python dictionary."""
+    logger.info(f"reading YAML file {yaml_fp} into dict")
+    with open(yaml_fp, "r") as fp:
+        yaml_dict = yaml.safe_load(fp)
+    return yaml_dict

--- a/tests/events/__init__/0101-debug.json
+++ b/tests/events/__init__/0101-debug.json
@@ -1,0 +1,5 @@
+{
+    "description": "Verify each package logger exists and is set to the DEBUG logging level",
+    "input": {},
+    "expected_output": {}
+}

--- a/tests/events/client/0101-create_boto3_client-client.json
+++ b/tests/events/client/0101-create_boto3_client-client.json
@@ -1,0 +1,7 @@
+{
+    "description": "Verify the boto3 BaseClient is created succesfully",
+    "input": {
+        "service_name": "s3"
+    },
+    "expected_output": {}
+}

--- a/tests/events/client/0201-create_boto3_client-exc.json
+++ b/tests/events/client/0201-create_boto3_client-exc.json
@@ -1,0 +1,9 @@
+{
+    "description": "Verify a boto UnknownServiceError is raised with a non-existent AWS service",
+    "input": {
+        "service_name": "service_name_that_does_not_exist",
+        "region": null,
+        "exception": "botoexceptions.UnknownServiceError"
+    },
+    "expected_output": {}
+}

--- a/tests/events/client/0202-create_boto3_client-exc.json
+++ b/tests/events/client/0202-create_boto3_client-exc.json
@@ -1,0 +1,9 @@
+{
+    "description": "Verify a boto InvalidRegionError is raised with a non-existent AWS region",
+    "input": {
+        "service_name": "s3",
+        "region": "a_region_that_does_not_exist",
+        "exception": "botoexceptions.InvalidRegionError"
+    },
+    "expected_output": {}
+}

--- a/tests/events/secrets/0101-get_secret_value-resp.json
+++ b/tests/events/secrets/0101-get_secret_value-resp.json
@@ -1,0 +1,24 @@
+{
+    "description": "Mock boto3 and verify the secret value is successfully retrieved",
+    "input": {
+        "stub": {
+            "method": "get_secret_value",
+            "parameters": {
+                "SecretId": "my-secret-id"
+            },
+            "response": {
+                "ARN": "arn:aws:secretsmanager:region:account-id:secret:my-secret-id",
+                "Name": "my-secret-id",
+                "VersionId": "EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE",
+                "SecretString": "{\"username\":\"my-username\",\"password\":\"my-password\"}",
+                "VersionStages": [
+                    "AWSCURRENT"
+                ],
+                "CreatedDate": 1620075600.0
+            }
+        }
+    },
+    "expected_output": {
+        "secret_value": "{\"username\":\"my-username\",\"password\":\"my-password\"}"
+    }
+}

--- a/tests/events/secrets/0201-get_secret_value-key_err.json
+++ b/tests/events/secrets/0201-get_secret_value-key_err.json
@@ -1,0 +1,21 @@
+{
+    "description": "Mock boto3 to trigger an expected KeyError",
+    "input": {
+        "stub": {
+            "method": "get_secret_value",
+            "parameters": {
+                "SecretId": "my-secret-id"
+            },
+            "response": {
+                "ARN": "arn:aws:secretsmanager:region:account-id:secret:my-secret-id",
+                "Name": "my-secret-id",
+                "VersionId": "EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE",
+                "VersionStages": [
+                    "AWSCURRENT"
+                ],
+                "CreatedDate": 1620075600.0
+            }
+        }
+    },
+    "expected_output": {}
+}

--- a/tests/events/secrets/0301-get_secret_value-exc.json
+++ b/tests/events/secrets/0301-get_secret_value-exc.json
@@ -1,0 +1,25 @@
+{
+    "description": "Mock boto3 to trigger an expected boto ClientError",
+    "input": {
+        "stub": {
+            "method": "get_secret_value",
+            "parameters": {
+                "SecretId": "nonexistent-secret-id"
+            },
+            "response": {
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "Secrets Manager can't find the specified secret.",
+                    "Type": "Client",
+                    "HttpStatusCode": 400
+                }
+            }
+        },
+        "exception": "botocore.exceptions.ClientError"
+    },
+    "expected_output": {
+        "error": {
+            "code": "ResourceNotFoundException"
+        }
+    }
+}

--- a/tests/events/sfn/0101-launch_sfn.json
+++ b/tests/events/sfn/0101-launch_sfn.json
@@ -1,0 +1,20 @@
+{
+    "description": "Mock boto3 and verify the stepfunctions execution is successfully launched",
+    "input": {
+        "stub": {
+            "method": "start_execution",
+            "parameters": {
+                "stateMachineArn": "arn:aws:states:region:account-id:stateMachine:stateMachineName",
+                "name": "executionName",
+                "input": "{\"key\": \"value\"}"
+            },
+            "response": {
+                "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName",
+                "startDate": "2024-07-22T00:00:00.000Z"
+            }
+        }
+    },
+    "expected_output": {
+        "execution_arn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName"
+    }
+}

--- a/tests/events/sfn/0201-poll_sfn.json
+++ b/tests/events/sfn/0201-poll_sfn.json
@@ -1,0 +1,39 @@
+{
+    "description": "Mock boto3 and verify the stepfunctions execution is successfully polled",
+    "input": {
+        "stub": {
+            "method": "describe_execution",
+            "parameters": {
+                "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName"
+            },
+            "response_running": {
+                "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName",
+                "stateMachineArn": "arn:aws:states:region:account-id:stateMachine:stateMachineName",
+                "name": "executionName",
+                "status": "RUNNING",
+                "startDate": "2024-07-22T00:00:00.000Z",
+                "input": "{\"key\": \"value\"}"
+            },
+            "response_succeeded": {
+                "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName",
+                "stateMachineArn": "arn:aws:states:region:account-id:stateMachine:stateMachineName",
+                "name": "executionName",
+                "status": "SUCCEEDED",
+                "startDate": "2024-07-22T00:00:00.000Z",
+                "stopDate": "2024-07-22T01:00:00.000Z",
+                "input": "{\"key\": \"value\"}",
+                "output": "{\"result\": \"success\"}"
+            }
+        }
+    },
+    "expected_output": {
+        "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName",
+        "stateMachineArn": "arn:aws:states:region:account-id:stateMachine:stateMachineName",
+        "name": "executionName",
+        "status": "SUCCEEDED",
+        "startDate": "2024-07-22T00:00:00.000Z",
+        "stopDate": "2024-07-22T01:00:00.000Z",
+        "input": "{\"key\": \"value\"}",
+        "output": "{\"result\": \"success\"}"
+    }
+}

--- a/tests/events/sfn/0301-get_exec_hist.json
+++ b/tests/events/sfn/0301-get_exec_hist.json
@@ -1,0 +1,79 @@
+{
+    "description": "Mock boto3 and verify the stepfunctions execution history is successfully retrieved",
+    "input": {
+        "stub": {
+            "method": "get_execution_history",
+            "parameters": {
+                "executionArn": "arn:aws:states:region:account-id:execution:stateMachineName:executionName",
+                "maxResults": 5,
+                "reverseOrder": true
+            },
+            "response": {
+                "events": [
+                    {
+                        "timestamp": "2024-07-22T01:00:00.000Z",
+                        "type": "ExecutionSucceeded",
+                        "id": 3,
+                        "previousEventId": 2,
+                        "executionSucceededEventDetails": {
+                            "output": "{\"result\": \"success\"}"
+                        }
+                    },
+                    {
+                        "timestamp": "2024-07-22T00:01:00.000Z",
+                        "type": "TaskStateEntered",
+                        "id": 2,
+                        "previousEventId": 1,
+                        "stateEnteredEventDetails": {
+                            "name": "TaskState",
+                            "input": "{\"key\": \"value\"}"
+                        }
+                    },
+                    {
+                        "timestamp": "2024-07-22T00:00:00.000Z",
+                        "type": "ExecutionStarted",
+                        "id": 1,
+                        "previousEventId": 0,
+                        "executionStartedEventDetails": {
+                            "input": "{\"key\": \"value\"}",
+                            "roleArn": "arn:aws:iam::account-id:role/role-name"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "expected_output": {
+        "events": [
+            {
+                "timestamp": "2024-07-22T01:00:00.000Z",
+                "type": "ExecutionSucceeded",
+                "id": 3,
+                "previousEventId": 2,
+                "executionSucceededEventDetails": {
+                    "output": "{\"result\": \"success\"}"
+                }
+            },
+            {
+                "timestamp": "2024-07-22T00:01:00.000Z",
+                "type": "TaskStateEntered",
+                "id": 2,
+                "previousEventId": 1,
+                "stateEnteredEventDetails": {
+                    "name": "TaskState",
+                    "input": "{\"key\": \"value\"}"
+                }
+            },
+            {
+                "timestamp": "2024-07-22T00:00:00.000Z",
+                "type": "ExecutionStarted",
+                "id": 1,
+                "previousEventId": 0,
+                "executionStartedEventDetails": {
+                    "input": "{\"key\": \"value\"}",
+                    "roleArn": "arn:aws:iam::account-id:role/role-name"
+                }
+            }
+        ]
+    }
+}

--- a/tests/events/ssm/0101-get_ssm_value-resp.json
+++ b/tests/events/ssm/0101-get_ssm_value-resp.json
@@ -1,0 +1,24 @@
+{
+    "description": "Mock boto3 and verify the systems manager parameter is successfully retrieved",
+    "input": {
+        "stub": {
+            "method": "get_parameter",
+            "parameters": {
+                "Name": "test_parameter"
+            },
+            "response": {
+                "Parameter": {
+                    "Name": "test_parameter",
+                    "Type": "String",
+                    "Value": "test_value",
+                    "Version": 1,
+                    "LastModifiedDate": "2024-07-22T00:00:00.000Z",
+                    "ARN": "arn:aws:ssm:region:account-id:parameter/test_parameter"
+                }
+            }
+        }
+    },
+    "expected_output": {
+        "ssm_value": "test_value"
+    }
+}

--- a/tests/events/ssm/0201-get_ssm_value-key_err.json
+++ b/tests/events/ssm/0201-get_ssm_value-key_err.json
@@ -1,0 +1,21 @@
+{
+    "description": "Mock boto3 to trigger an expected KeyError",
+    "input": {
+        "stub": {
+            "method": "get_parameter",
+            "parameters": {
+                "Name": "test_parameter"
+            },
+            "response": {
+                "Parameter": {
+                    "Name": "test_parameter",
+                    "Type": "String",
+                    "Version": 1,
+                    "LastModifiedDate": "2024-07-22T00:00:00.000Z",
+                    "ARN": "arn:aws:ssm:region:account-id:parameter/test_parameter"
+                }
+            }
+        }
+    },
+    "expected_output": {}
+}

--- a/tests/events/ssm/0301-get_ssm_value-exc.json
+++ b/tests/events/ssm/0301-get_ssm_value-exc.json
@@ -1,0 +1,25 @@
+{
+    "description": "Mock boto3 to trigger an expected boto ClientError",
+    "input": {
+        "stub": {
+            "method": "get_parameter",
+            "parameters": {
+                "Name": "test_parameter"
+            },
+            "response": {
+                "Error": {
+                    "Code": "ParameterNotFound",
+                    "Message": "Parameter test_parameter not found.",
+                    "Type": "Client",
+                    "HttpStatusCode": 400
+                }
+            }
+        },
+        "exception": "botocore.exceptions.ClientError"
+    },
+    "expected_output": {
+        "error": {
+            "code": "ParameterNotFound"
+        }
+    }
+}

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    slow: This test runs a bit slow
+    happy: Testing valid inputs and typical conditions behave as expected
+    sad: Testing with invalid inputs or unexpected conditions, ensure errors and edge cases are handled gracefully

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+--trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org
+pytest~=8.0
+pytest-cov~=5.0
+pytest-xdist~=3.6
+pyyaml~=6.0

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,0 +1,48 @@
+import logging
+import os
+import sys
+
+import pytest
+
+from topshelfsoftware_util.log import get_logger
+
+from conftest import get_json_files
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+from __setup__ import TEST_EVENTS_PATH
+
+MODULE = "__init__"
+MODULE_EVENTS_DIR = os.path.join(TEST_EVENTS_PATH, MODULE)
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger(f"test_{MODULE}", stream=sys.stdout)
+
+# ----------------------------------------------------------------------------#
+#                           --- Module Imports ---                            #
+# ----------------------------------------------------------------------------#
+from topshelfsoftware_aws_util import debug, get_package_loggers  # noqa: E402
+
+
+# ----------------------------------------------------------------------------#
+#                                --- TESTS ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file", get_json_files(MODULE_EVENTS_DIR, ["debug"])
+)
+def test_01_debug(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    pkg_loggers = get_package_loggers()
+    assert all(
+        isinstance(pkg_logger, logging.Logger) for pkg_logger in pkg_loggers
+    ), f"Not all elements are of type {logging.Logger}"
+
+    debug()
+    assert all(
+        pkg_logger.level == logging.DEBUG for pkg_logger in pkg_loggers
+    ), f"Not all loggers are at the {logging.DEBUG} level"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,65 @@
+import logging
+import os
+import sys
+
+from botocore import exceptions as botoexceptions  # noqa: F401
+import pytest
+
+from topshelfsoftware_aws_util.client import logger as client_logger
+from topshelfsoftware_util.log import add_log_stream, get_logger
+
+from conftest import get_json_files
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+from __setup__ import TEST_EVENTS_PATH
+
+MODULE = "client"
+MODULE_EVENTS_DIR = os.path.join(TEST_EVENTS_PATH, MODULE)
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger(f"test_{MODULE}", stream=sys.stdout)
+add_log_stream(client_logger, level=logging.DEBUG, stream=sys.stdout)
+
+# ----------------------------------------------------------------------------#
+#                           --- Module Imports ---                            #
+# ----------------------------------------------------------------------------#
+from topshelfsoftware_aws_util.client import (  # noqa: E402
+    BaseClient,
+    create_boto3_client,
+)
+
+
+# ----------------------------------------------------------------------------#
+#                                --- TESTS ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["create_boto3_client", "client"]),
+)
+def test_01_create_boto3_client(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    svc_name: str = get_event_as_dict["input"]["service_name"]
+    client = create_boto3_client(svc_name)
+    assert isinstance(client, BaseClient)
+
+
+@pytest.mark.sad
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["create_boto3_client", "exc"]),
+)
+def test_02_create_boto3_client(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    service_name: str = get_event_as_dict["input"]["service_name"]
+    region: str = get_event_as_dict["input"]["region"]
+    exception: str = get_event_as_dict["input"]["exception"]
+
+    with pytest.raises(eval(exception)):
+        create_boto3_client(service_name, region)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,129 @@
+import logging
+import os
+import sys
+
+import botocore  # noqa: F401
+from botocore.stub import Stubber
+import pytest
+
+from topshelfsoftware_aws_util.secrets import logger as secrets_logger
+from topshelfsoftware_util.log import add_log_stream, get_logger
+
+from conftest import get_json_files
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+from __setup__ import TEST_EVENTS_PATH
+
+MODULE = "secrets"
+MODULE_EVENTS_DIR = os.path.join(TEST_EVENTS_PATH, MODULE)
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger(f"test_{MODULE}", stream=sys.stdout)
+add_log_stream(secrets_logger, level=logging.DEBUG, stream=sys.stdout)
+
+# ----------------------------------------------------------------------------#
+#                           --- Module Imports ---                            #
+# ----------------------------------------------------------------------------#
+from topshelfsoftware_aws_util.secrets import (  # noqa: E402
+    secret_client,
+    get_secret_value,
+)
+
+
+# ----------------------------------------------------------------------------#
+#                                --- TESTS ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_secret_value", "resp"]),
+)
+def test_01_get_secret_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    expected_output: dict = get_event_as_dict["expected_output"]
+
+    # Stub the boto3 client
+    stubber = Stubber(secret_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        secret = get_secret_value(stub_params["SecretId"])
+        assert secret == expected_output["secret_value"]
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.sad
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_secret_value", "key_err"]),
+)
+def test_02_get_secret_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+
+    # Stub the boto3 client
+    stubber = Stubber(secret_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        with pytest.raises(KeyError):
+            get_secret_value(stub_params["SecretId"])
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.sad
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_secret_value", "exc"]),
+)
+def test_03_get_secret_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    exception: str = get_event_as_dict["input"]["exception"]
+
+    # Stub the boto3 client
+    stubber = Stubber(secret_client)
+    stubber.add_client_error(
+        stub_method,
+        service_error_code=stub_resp["Error"]["Code"],
+        service_message=stub_resp["Error"]["Message"],
+        http_status_code=stub_resp["Error"]["HttpStatusCode"],
+        expected_params=stub_params
+    )
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        with pytest.raises(eval(exception)):
+            get_secret_value(stub_params["SecretId"])
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -114,7 +114,7 @@ def test_03_get_secret_value(get_event_as_dict):
         service_error_code=stub_resp["Error"]["Code"],
         service_message=stub_resp["Error"]["Message"],
         http_status_code=stub_resp["Error"]["HttpStatusCode"],
-        expected_params=stub_params
+        expected_params=stub_params,
     )
 
     try:

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -1,0 +1,140 @@
+import json
+import logging
+import os
+import sys
+
+from botocore.stub import Stubber
+import pytest
+
+from topshelfsoftware_aws_util.sfn import logger as sfn_logger
+from topshelfsoftware_util.common import logger as common_logger
+from topshelfsoftware_util.log import add_log_stream, get_logger
+
+from conftest import get_json_files
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+from __setup__ import TEST_EVENTS_PATH
+
+MODULE = "sfn"
+MODULE_EVENTS_DIR = os.path.join(TEST_EVENTS_PATH, MODULE)
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger(f"test_{MODULE}", stream=sys.stdout)
+add_log_stream(sfn_logger, level=logging.DEBUG, stream=sys.stdout)
+add_log_stream(common_logger, level=logging.DEBUG, stream=sys.stdout)
+
+# ----------------------------------------------------------------------------#
+#                           --- Module Imports ---                            #
+# ----------------------------------------------------------------------------#
+from topshelfsoftware_aws_util.sfn import (  # noqa: E402
+    sfn_client,
+    launch_sfn,
+    poll_sfn,
+    get_exec_hist,
+)
+
+
+# ----------------------------------------------------------------------------#
+#                                --- TESTS ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["launch_sfn"]),
+)
+def test_01_launch_sfn(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    expected_output: dict = get_event_as_dict["expected_output"]
+
+    # Stub the boto3 client
+    stubber = Stubber(sfn_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        execution_arn = launch_sfn(
+            stub_params["stateMachineArn"],
+            json.loads(stub_params["input"]),
+            stub_params["name"],
+        )
+        assert execution_arn == expected_output["execution_arn"]
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["poll_sfn"]),
+)
+def test_02_poll_sfn(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp_running: dict = get_event_as_dict["input"]["stub"][
+        "response_running"
+    ]
+    stub_resp_succeeded: dict = get_event_as_dict["input"]["stub"][
+        "response_succeeded"
+    ]
+    expected_output: dict = get_event_as_dict["expected_output"]
+
+    # Stub the boto3 client
+    stubber = Stubber(sfn_client)
+    stubber.add_response(stub_method, stub_resp_running, stub_params)
+    stubber.add_response(stub_method, stub_resp_succeeded, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        sfn_resp = poll_sfn(stub_params["executionArn"], step=0.01)
+        assert sfn_resp == expected_output
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_exec_hist"]),
+)
+def test_03_get_exec_hist(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    expected_output: dict = get_event_as_dict["expected_output"]
+
+    # Stub the boto3 client
+    stubber = Stubber(sfn_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        events = get_exec_hist(
+            stub_params["executionArn"],
+        )
+        assert events == expected_output
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -114,7 +114,7 @@ def test_03_get_ssm_value(get_event_as_dict):
         service_error_code=stub_resp["Error"]["Code"],
         service_message=stub_resp["Error"]["Message"],
         http_status_code=stub_resp["Error"]["HttpStatusCode"],
-        expected_params=stub_params
+        expected_params=stub_params,
     )
 
     try:

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,0 +1,129 @@
+import logging
+import os
+import sys
+
+import botocore  # noqa: F401
+from botocore.stub import Stubber
+import pytest
+
+from topshelfsoftware_aws_util.ssm import logger as ssm_logger
+from topshelfsoftware_util.log import add_log_stream, get_logger
+
+from conftest import get_json_files
+
+# ----------------------------------------------------------------------------#
+#                               --- Globals ---                               #
+# ----------------------------------------------------------------------------#
+from __setup__ import TEST_EVENTS_PATH
+
+MODULE = "ssm"
+MODULE_EVENTS_DIR = os.path.join(TEST_EVENTS_PATH, MODULE)
+
+# ----------------------------------------------------------------------------#
+#                               --- Logging ---                               #
+# ----------------------------------------------------------------------------#
+logger = get_logger(f"test_{MODULE}", stream=sys.stdout)
+add_log_stream(ssm_logger, level=logging.DEBUG, stream=sys.stdout)
+
+# ----------------------------------------------------------------------------#
+#                           --- Module Imports ---                            #
+# ----------------------------------------------------------------------------#
+from topshelfsoftware_aws_util.ssm import (  # noqa: E402
+    ssm_client,
+    get_ssm_value,
+)
+
+
+# ----------------------------------------------------------------------------#
+#                                --- TESTS ---                                #
+# ----------------------------------------------------------------------------#
+@pytest.mark.happy
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_ssm_value", "resp"]),
+)
+def test_01_get_ssm_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    expected_output: dict = get_event_as_dict["expected_output"]
+
+    # Stub the boto3 client
+    stubber = Stubber(ssm_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        secret = get_ssm_value(stub_params["Name"])
+        assert secret == expected_output["ssm_value"]
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.sad
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_ssm_value", "key_err"]),
+)
+def test_02_get_ssm_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+
+    # Stub the boto3 client
+    stubber = Stubber(ssm_client)
+    stubber.add_response(stub_method, stub_resp, stub_params)
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        with pytest.raises(KeyError):
+            get_ssm_value(stub_params["Name"])
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()
+
+
+@pytest.mark.sad
+@pytest.mark.parametrize("event_dir", [MODULE_EVENTS_DIR])
+@pytest.mark.parametrize(
+    "event_file",
+    get_json_files(MODULE_EVENTS_DIR, ["get_ssm_value", "exc"]),
+)
+def test_03_get_ssm_value(get_event_as_dict):
+    logger.info(f"Test Description: {get_event_as_dict['description']}")
+    stub_method: str = get_event_as_dict["input"]["stub"]["method"]
+    stub_params: dict = get_event_as_dict["input"]["stub"]["parameters"]
+    stub_resp: dict = get_event_as_dict["input"]["stub"]["response"]
+    exception: str = get_event_as_dict["input"]["exception"]
+
+    # Stub the boto3 client
+    stubber = Stubber(ssm_client)
+    stubber.add_client_error(
+        stub_method,
+        service_error_code=stub_resp["Error"]["Code"],
+        service_message=stub_resp["Error"]["Message"],
+        http_status_code=stub_resp["Error"]["HttpStatusCode"],
+        expected_params=stub_params
+    )
+
+    try:
+        # Activate the stubber
+        stubber.activate()
+
+        # Test the source code
+        with pytest.raises(eval(exception)):
+            get_ssm_value(stub_params["Name"])
+    finally:
+        # Deactivate the stubber
+        stubber.deactivate()

--- a/topshelfsoftware_aws_util/__init__.py
+++ b/topshelfsoftware_aws_util/__init__.py
@@ -25,6 +25,5 @@ def _set_logger_levels(level: Union[int, str]):
     loggers = get_package_loggers()
     for logger in loggers:
         logger.setLevel(level)
-        for handler in logger.handlers:
-            handler.setLevel(level)
+        [handler.setLevel(level) for handler in logger.handlers]
     return

--- a/topshelfsoftware_aws_util/__init__.py
+++ b/topshelfsoftware_aws_util/__init__.py
@@ -17,9 +17,7 @@ def debug():
 
 def get_package_loggers() -> List[logging.Logger]:
     """Retrieve a list of the Loggers used in the package."""
-    loggers = [
-        client_logger, secrets_logger, sfn_logger, ssm_logger
-    ]
+    loggers = [client_logger, secrets_logger, sfn_logger, ssm_logger]
     return loggers
 
 

--- a/topshelfsoftware_aws_util/client.py
+++ b/topshelfsoftware_aws_util/client.py
@@ -2,7 +2,7 @@
 
 from boto3.session import Session as Boto3Session
 from botocore.client import BaseClient
-from botocore.exceptions import ClientError as BotoClientError
+from botocore.exceptions import InvalidRegionError, UnknownServiceError
 
 from topshelfsoftware_util.log import get_logger
 
@@ -30,8 +30,11 @@ def create_boto3_client(service_name: str, region: str = None) -> BaseClient:
     try:
         session = Boto3Session(region_name=region)
         client = session.client(service_name=service_name)
-    except BotoClientError as e:
-        logger.error(f"failed to create client: {service_name}. Reason: {e}")
+    except UnknownServiceError as e:
+        logger.error(f"Unknown service specified: {service_name}")
+        raise e
+    except InvalidRegionError as e:
+        logger.error(f"Invalid region specified: {region}")
         raise e
     logger.debug("boto3 client successfully created")
     return client

--- a/topshelfsoftware_aws_util/client.py
+++ b/topshelfsoftware_aws_util/client.py
@@ -16,11 +16,11 @@ def create_boto3_client(service_name: str, region: str = None) -> BaseClient:
     ----------
     service_name: str
         Name of the AWS service.
-    
+
     region: str, optional
         Region where service abides.
         Default is `None`.
-    
+
     Returns
     -------
     botocore.client.BaseClient

--- a/topshelfsoftware_aws_util/secrets.py
+++ b/topshelfsoftware_aws_util/secrets.py
@@ -17,7 +17,7 @@ def get_secret_value(secret_id: str) -> str:
     ----------
     secret_id: str
         The ARN or name of the secret to retrieve.
-    
+
     Returns
     -------
     str
@@ -32,7 +32,10 @@ def get_secret_value(secret_id: str) -> str:
         logger.error(f"failed to retrieve secret: {secret_id}. Reason: {e}")
         raise e
     except KeyError as e:
-        logger.error(f"failed to retrieve string from secretsmanager response: {secret_id}. Reason: {e}")
+        logger.error(
+            f"failed to retrieve string from secretsmanager response: "
+            f"{secret_id}. Reason: {e}"
+        )
         raise e
     logger.debug("secret string: <redacted>")
     return val

--- a/topshelfsoftware_aws_util/sfn.py
+++ b/topshelfsoftware_aws_util/sfn.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__, stream=None)
 
 class SfnStatus(str, Enum):
     """Enumeration for step function status."""
+
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
@@ -24,15 +25,15 @@ class SfnStatus(str, Enum):
 
 def launch_sfn(state_machine_arn: str, payload: dict) -> str:
     """Launch the step function with the specified payload.
-    
+
     Parameters
     ----------
     state_machine_arn: str
         The ARN of the state machine.
-    
+
     payload: dict
         Payload input to supply to the state machine.
-    
+
     Returns
     -------
     str
@@ -58,16 +59,16 @@ def launch_sfn(state_machine_arn: str, payload: dict) -> str:
 def poll_sfn(execution_arn: str, step: float = 1) -> dict:
     """Poll the step function for status.
     Return the execution response once the status is no longer `RUNNING`.
-    
+
     Parameters
     ----------
     execution_arn: str
         Step Functions execution ARN.
-    
+
     step: float, Optional
         Amount of time (in sec) to wait between poll attempts.
         Default is 1 second.
-    
+
     Returns
     -------
     dict
@@ -78,7 +79,7 @@ def poll_sfn(execution_arn: str, step: float = 1) -> dict:
     while sfn_status == SfnStatus.RUNNING.value:
         time.sleep(step)
         n += 1
-        
+
         logger.debug(f"polling execution arn: {execution_arn}")
         res = sfn_client.describe_execution(executionArn=execution_arn)
         logger.info(f"poll #{n:02d} response: {fmt_json(res)}")
@@ -90,25 +91,23 @@ def poll_sfn(execution_arn: str, step: float = 1) -> dict:
 
 def get_exec_hist(execution_arn: str, max_results: int = 5) -> dict:
     """Retrieve the step function execution history.
-    
+
     Parameters
     ----------
     execution_arn: str
         Step Functions execution ARN.
-    
+
     max_results: int, Optional
         Number of events to retrieve from the execution.
         Default is 5.
-    
+
     Returns
     -------
     dict
         Step Functions execution history.
     """
     exec_history = sfn_client.get_execution_history(
-        executionArn=execution_arn,
-        maxResults=max_results,
-        reverseOrder=True
+        executionArn=execution_arn, maxResults=max_results, reverseOrder=True
     )
     logger.info(f"execution history: {fmt_json(exec_history)}")
     return exec_history

--- a/topshelfsoftware_aws_util/sfn.py
+++ b/topshelfsoftware_aws_util/sfn.py
@@ -2,10 +2,10 @@
 
 from enum import Enum
 import json
-import time
 import uuid
 
 from topshelfsoftware_aws_util.client import create_boto3_client
+from topshelfsoftware_util.common import delay
 from topshelfsoftware_util.json import fmt_json
 from topshelfsoftware_util.log import get_logger
 
@@ -23,7 +23,7 @@ class SfnStatus(str, Enum):
     ABORTED = "ABORTED"
 
 
-def launch_sfn(state_machine_arn: str, payload: dict) -> str:
+def launch_sfn(state_machine_arn: str, payload: dict, name: str = None) -> str:
     """Launch the step function with the specified payload.
 
     Parameters
@@ -34,19 +34,23 @@ def launch_sfn(state_machine_arn: str, payload: dict) -> str:
     payload: dict
         Payload input to supply to the state machine.
 
+    name: str, Optional
+        The execution name of the state machine.
+        Default of `None` generates a random UUID for the name.
+
     Returns
     -------
     str
         Step Functions execution ARN.
     """
-    uid = str(uuid.uuid4())
-    logger.info(f"Execution name: {uid}")
+    name = str(uuid.uuid4()) if name is None else name
+    logger.info(f"Execution name: {name}")
 
     # run step function
     logger.info(f"Launching step function: {state_machine_arn}")
     res = sfn_client.start_execution(
         stateMachineArn=state_machine_arn,
-        name=uid,
+        name=name,
         input=json.dumps(payload),
     )
 
@@ -77,7 +81,7 @@ def poll_sfn(execution_arn: str, step: float = 1) -> dict:
     sfn_status = SfnStatus.RUNNING.value
     n = 0
     while sfn_status == SfnStatus.RUNNING.value:
-        time.sleep(step)
+        delay(step)
         n += 1
 
         logger.debug(f"polling execution arn: {execution_arn}")

--- a/topshelfsoftware_aws_util/ssm.py
+++ b/topshelfsoftware_aws_util/ssm.py
@@ -17,7 +17,7 @@ def get_ssm_value(name: str) -> str:
     ----------
     name: str
         Name of the SSM parameter.
-    
+
     Returns
     -------
     str
@@ -32,7 +32,10 @@ def get_ssm_value(name: str) -> str:
         logger.error(f"failed to retrieve ssm parameter: {name}. Reason: {e}")
         raise e
     except KeyError as e:
-        logger.error(f"failed to retrieve parameter value from ssm response: {name}. Reason: {e}")
+        logger.error(
+            f"failed to retrieve parameter value from ssm response: "
+            f"{name}. Reason: {e}"
+        )
         raise e
     logger.debug(f"ssm parameter value: {val}")
     return val


### PR DESCRIPTION
Addresses #5 

In addition to adding unit tests, the following was accomplished:
- CI/CD workflows added using GitHub Actions including:
  - Unit tests
  - Package build
  - Code coverage with Codecov
- Makefile overhauled with big improvements to streamline development
- Ensuring code quality with linting/formatting and pre-commit & pre-push hooks
- Badges included in README for quick snapshot on repo health